### PR TITLE
Memory protection enabled

### DIFF
--- a/ports/unix/proj/scion/lwipopts.h
+++ b/ports/unix/proj/scion/lwipopts.h
@@ -68,7 +68,7 @@
  * critical regions during buffer allocation, deallocation and memory
  * allocation and deallocation.
  */
-#define SYS_LIGHTWEIGHT_PROT            0
+#define SYS_LIGHTWEIGHT_PROT            1
 
 /**
  * NO_SYS==1: Provides VERY minimal functionality. Otherwise,


### PR DESCRIPTION
It fixes crashing stack under heavy load.
Ref: http://lwip.100.n7.nabble.com/FYI-STM32F4xx-demo-code-and-probably-others-with-FreeRTOS-doesn-t-set-SYS-LIGHTWEIGHT-PROT-1-td20590.html

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip-contrib/5)

<!-- Reviewable:end -->
