### PR TITLE
LWIP_SO_RCVBUF=1

### DIFF
--- a/ports/unix/proj/scion/lwipopts.h
+++ b/ports/unix/proj/scion/lwipopts.h
@@ -350,7 +350,10 @@
 /* Enable recv() timeout */
 #define LWIP_SO_RCVTIMEO                1
 
-/* Enable SO_REUSEADDR and SO_REUSEPORT options */
-#define SO_REUSE 1
+/* Enable SO_REUSEADDR and SO_REUSEPORT options. */
+#define SO_REUSE                        1
+
+/* Enable SO_RCVBUF processing. */
+#define LWIP_SO_RCVBUF                  1
 
 #endif /* __LWIPOPTS_H__ */


### PR DESCRIPTION
Enables `SO_RCVBUF`. In particular, it allows to check whether there is some received by a netconn's socket (with that info we don't need callbacks anymore).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip-contrib/8)
<!-- Reviewable:end -->
